### PR TITLE
fix: Cambiar la importación de chalk a require para evitar problemas …

### DIFF
--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,7 +1,9 @@
 import { Message } from 'discord.js';
 import fs from 'fs';
 import path from 'path';
-import chalk from 'chalk';
+// TODO: quitar esta linea de alguna forma
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const chalk = require('chalk');
 
 export class CommandLogger {
   private static logFile = path.join(process.cwd(), 'history.log');


### PR DESCRIPTION
This pull request includes a small change to the `src/utils/logger.ts` file. The change addresses an issue with the import of the `chalk` library by temporarily using `require` instead of `import`.

* [`src/utils/logger.ts`](diffhunk://#diff-0b242f99cdb5b36e8a0aa886862c30c2f480aca7512bcfc3e2fa4889055d4544L4-R6): Replaced the `chalk` import statement with a `require` statement and added a TODO comment to address this in the future.…de compatibilidad